### PR TITLE
Update `pyhmmer` and implement conversion of `HmmRecord` from `Hit`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ pybarrnap = "pybarrnap.scripts.pybarrnap:main"
 [tool.poetry.dependencies]
 python = "^3.8"
 biopython = ">=1.79"
-pyhmmer = ">=0.10.4"
+pyhmmer = ">=0.10.8"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.1.6"

--- a/src/pybarrnap/barrnap.py
+++ b/src/pybarrnap/barrnap.py
@@ -12,8 +12,8 @@ import pyhmmer
 from Bio import SeqIO
 from Bio.SeqRecord import SeqRecord
 from pyhmmer import nhmmer
-from pyhmmer.easel import Alphabet, DigitalSequence, DigitalSequenceBlock, TextSequence
-from pyhmmer.plan7 import Builder, HMMFile
+from pyhmmer.easel import Alphabet, DigitalSequenceBlock, TextSequence
+from pyhmmer.plan7 import HMMFile
 
 import pybarrnap
 from pybarrnap.config import KINGDOM2HMM_FILE, KINGDOMS, MAXLEN, SEQTYPE2LEN

--- a/src/pybarrnap/barrnap.py
+++ b/src/pybarrnap/barrnap.py
@@ -86,12 +86,12 @@ class Barrnap:
 
         # Convert SeqRecord to DigitalSequenceBlock for pyhmmer.nhmmer execution
         try:
-            seqs: list[DigitalSequence] = []
+            alphabet = Alphabet.rna()
+            self._seqs = DigitalSequenceBlock(alphabet)
             for rec in seq_records:
                 name, description = rec.name.encode(), rec.description.encode()
                 seq = TextSequence(name, description, sequence=str(rec.seq))
-                seqs.append(seq.digitize(Alphabet.rna()))
-            self._seqs = DigitalSequenceBlock(Alphabet.rna(), seqs)
+                self._seqs.append(seq.digitize(alphabet))
         except ValueError as e:
             logger.error(f"pybarrnap failed to run. {e}. Protein fasta as input?")
             exit(1)

--- a/src/pybarrnap/record.py
+++ b/src/pybarrnap/record.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Iterable
 
 from Bio.SeqFeature import SeqFeature, SimpleLocation
+from pyhmmer.plan7 import Hit
 
 import pybarrnap
 from pybarrnap.config import SEQTYPE2LEN
@@ -46,6 +48,36 @@ class HmmRecord:
     def product(self) -> str:
         """product"""
         return self.query_name.replace("_r", " ribosomal ").replace("5_8", "5.8")
+
+    @staticmethod
+    def from_hit(hit: Hit) -> HmmRecord:
+        records = []
+        query_name = hit.hits.query_name.decode()
+        query_acc = "-" if hit.hits.query_accession is None else hit.hits.query_accession.decode()
+        dom = hit.best_domain
+        ali = dom.alignment
+        target_name = hit.name.decode()
+        target_acc = "-" if hit.accession is None else hit.accession.decode()
+        desc = "-" if hit.description is None else hit.description.decode()
+        return HmmRecord(
+            target_name=target_name,
+            target_acc=target_acc,
+            query_name=query_name,
+            query_acc=query_acc,
+            hmm_from=ali.hmm_from,
+            hmm_to=ali.hmm_to,
+            ali_from=ali.target_from,
+            ali_to=ali.target_to,
+            env_from=dom.env_from,
+            env_to=dom.env_to,
+            sq_len=ali.target_length,
+            strand=dom.strand,
+            evalue=hit.evalue,
+            score=hit.score,
+            bias=dom.bias,
+            description=desc,
+        )
+
 
     @staticmethod
     def parse_lines(lines: list[str]) -> list[HmmRecord]:

--- a/src/pybarrnap/record.py
+++ b/src/pybarrnap/record.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable
 
 from Bio.SeqFeature import SeqFeature, SimpleLocation
 from pyhmmer.plan7 import Hit

--- a/src/pybarrnap/record.py
+++ b/src/pybarrnap/record.py
@@ -48,17 +48,21 @@ class HmmRecord:
         """product"""
         return self.query_name.replace("_r", " ribosomal ").replace("5_8", "5.8")
 
-    @staticmethod
-    def from_hit(hit: Hit) -> HmmRecord:
-        records = []
+    @classmethod
+    def from_hit(cls, hit: Hit) -> HmmRecord:
+        """Create a new record from a PyHMMER ``Hit``"""
         query_name = hit.hits.query_name.decode()
-        query_acc = "-" if hit.hits.query_accession is None else hit.hits.query_accession.decode()
+        query_acc = (
+            "-"
+            if hit.hits.query_accession is None
+            else hit.hits.query_accession.decode()
+        )
         dom = hit.best_domain
         ali = dom.alignment
         target_name = hit.name.decode()
         target_acc = "-" if hit.accession is None else hit.accession.decode()
         desc = "-" if hit.description is None else hit.description.decode()
-        return HmmRecord(
+        return cls(
             target_name=target_name,
             target_acc=target_acc,
             query_name=query_name,
@@ -76,7 +80,6 @@ class HmmRecord:
             bias=dom.bias,
             description=desc,
         )
-
 
     @staticmethod
     def parse_lines(lines: list[str]) -> list[HmmRecord]:


### PR DESCRIPTION
Hi @moshi4,

I made a new PyHMMER release (`v0.10.8`) to address #2, now the E-values are changed based on the window length. I also added the new `Domain.strand` property to get the strand where a domain is located, so now you can create a `HmmRecord` directly from a `Hit` without having to write an intermediate table; this should be a little bit faster but also give you access to the full E-values (and not rounded ones like the HMMER table gives you).

I also updated `Barrnap` so that the HMMs are pre-fetched on object creation: at the moment, passing a file to `pyhmmer.nhmmer` causes the file to be rewinded and parsed for every query sequence. This is usually done to save memory, but since you have very few HMMs it's fine pre-loading them in memory so that the PyHMMER dispatcher can do a better job.

If you're okay with it, I'll also make another PR to change the exception handling (a "well-behaved" Python library shouldn't do system exits, only scripts should do that).