### PR TITLE
Update exception management and command line interface

### DIFF
--- a/src/pybarrnap/__main__.py
+++ b/src/pybarrnap/__main__.py
@@ -1,0 +1,2 @@
+from pybarrnap.scripts.pybarrnap import main
+main()

--- a/src/pybarrnap/__main__.py
+++ b/src/pybarrnap/__main__.py
@@ -1,2 +1,3 @@
 from pybarrnap.scripts.pybarrnap import main
+
 main()

--- a/src/pybarrnap/barrnap.py
+++ b/src/pybarrnap/barrnap.py
@@ -90,7 +90,9 @@ class Barrnap:
                 seq = TextSequence(name, description, sequence=str(rec.seq))
                 self._seqs.append(seq.digitize(alphabet))
         except ValueError as e:
-            raise ValueError("Failed to convert nucleotide sequences, maybe input contains proteins?") from e
+            raise ValueError(
+                "Failed to convert nucleotide sequences, maybe input contains proteins?"
+            ) from e
 
         # Set parameters
         self._evalue = evalue

--- a/src/pybarrnap/barrnap.py
+++ b/src/pybarrnap/barrnap.py
@@ -75,13 +75,10 @@ class Barrnap:
         else:
             seq_records = fasta
         if len(seq_records) == 0:
-            logger.error("No sequence found in input fasta!!")
-            exit(1)
+            raise ValueError("No sequence found in input records")
         fasta_name_list = [str(rec.name) for rec in seq_records]
         if len(set(fasta_name_list)) != len(fasta_name_list):
-            logger.error("Duplicate name is contained in input fasta!!")
-            logger.error(f"Fasta name list = {fasta_name_list}")
-            exit(1)
+            raise ValueError("Duplicate names in input records")
         self._seq_records = seq_records
 
         # Convert SeqRecord to DigitalSequenceBlock for pyhmmer.nhmmer execution
@@ -93,8 +90,7 @@ class Barrnap:
                 seq = TextSequence(name, description, sequence=str(rec.seq))
                 self._seqs.append(seq.digitize(alphabet))
         except ValueError as e:
-            logger.error(f"pybarrnap failed to run. {e}. Protein fasta as input?")
-            exit(1)
+            raise ValueError("Failed to convert nucleotide sequences, maybe input contains proteins?") from e
 
         # Set parameters
         self._evalue = evalue

--- a/tests/test_barrnap.py
+++ b/tests/test_barrnap.py
@@ -63,21 +63,21 @@ def test_mitochondria_run():
 def test_null_fasta_run_failed():
     """Test pybarrnap run for null fasta file (failed)"""
     null_fasta_file = load_example_fasta_file("null.fna")
-    with pytest.raises(SystemExit):
+    with pytest.raises(ValueError):
         Barrnap(null_fasta_file)
 
 
 def test_dupid_fasta_run_failed():
     """Test pybarrnap run for duplication id fasta file (failed)"""
     dupid_fasta_file = load_example_fasta_file("dupid.fna")
-    with pytest.raises(SystemExit):
+    with pytest.raises(ValueError):
         Barrnap(dupid_fasta_file)
 
 
 def test_protein_fasta_run_failed():
     """Test pybarrnap run for protein fasta file (failed)"""
     protein_fasta_file = load_example_fasta_file("protein.fna")
-    with pytest.raises(SystemExit):
+    with pytest.raises(ValueError):
         Barrnap(protein_fasta_file)
 
 


### PR DESCRIPTION
This PR changes the following:

- Remove all hard `exit` from the `Barrnap` class, so that usage of `pybarrnap` as a library never exits the Python interpreter. Instead, the errors are all communicated as Python exceptions. 
- Add a `__main__.py` file so that the script can be invoked as `python -m pybarrnap`, which can be useful on some environments where the Python script gets installed to a folder that is not in `$PATH`. 
- Use `sys.exit` rather than `exit`, the latter should only be used in interactive sessions (see https://stackoverflow.com/questions/6501121/difference-between-exit-and-sys-exit-in-python/6501134#6501134)
- Exit with proper error numbers to report the different kind of exceptions raised by the package.
- Return `-signal.SIGINT` on `KeyboardInterrupt` to be POSIX-compliant.